### PR TITLE
Fixed endianness

### DIFF
--- a/Week 01/ipAddress.cpp
+++ b/Week 01/ipAddress.cpp
@@ -12,10 +12,10 @@ int main()
 	IpAddress myAddress;
 	myAddress.address = 16777343;
 	
-	std::cout << (int)myAddress.octets[0] << "." 
-	          << (int)myAddress.octets[1] << "." 
+	std::cout << (int)myAddress.octets[3] << "." 
 	          << (int)myAddress.octets[2] << "." 
-	          << (int)myAddress.octets[3];
+	          << (int)myAddress.octets[1] << "." 
+	          << (int)myAddress.octets[0];
 	
 }
 


### PR DESCRIPTION
Shouldn't we print the octets backwards since we are assuming little-endian machine?