### PR TITLE
Update StringPool.cpp

### DIFF
--- a/Week 08/ImmutableString/StringPool.cpp
+++ b/Week 08/ImmutableString/StringPool.cpp
@@ -41,7 +41,13 @@ const char* StringPool::getAllocatedString(const char* str)
 void StringPool::removeRecord(unsigned index)
 {
 	std::swap(stringRecords[index], stringRecords[stringCount - 1]);
+	
 	delete[] stringRecords[stringCount - 1].str;
+	
+	stringRecords[stringCount - 1].str = nullptr;
+        stringRecords[stringCount - 1].refCount = 0;
+	
+        stringCount--;
 }
 
 void StringPool::releaseString(const char* str)


### PR DESCRIPTION
За да има някакъв смисъл размяната на двата обекта (този, който искаме да изтрием, и последния), трябва да намалим общия брой (stringCount), който използваме като индексатор, иначе пак ще остане "дупка". Броят си остава същият и при следващото писане ще пишем точно след последната клетка, която е вече празна. Със същия успех можем просто да освободим stringRecords[index].