### PR TITLE
cosmetic change ImmutableString.h

### DIFF
--- a/Week 08/ImmutableString/ImmutableString.h
+++ b/Week 08/ImmutableString/ImmutableString.h
@@ -1,5 +1,4 @@
 #pragma once
-#pragma once
 #include <iostream>
 #include "StringPool.h"
 
@@ -25,7 +24,6 @@ private:
 	void copyFrom(const ImmutableString& data);
 	void free();
 
-	explicit ImmutableString(size_t capacity); 
 	static StringPool _pool;
 };
 


### PR DESCRIPTION
1. removed #pragma once, written twice
2. removed explicit constr, accepting capacity (not implemented, and never used), could be implemented, but not necessary