### PR TITLE
Update Rectangle.cpp

### DIFF
--- a/Week 11/Example_polymorphism/Rectangle.cpp
+++ b/Week 11/Example_polymorphism/Rectangle.cpp
@@ -20,6 +20,6 @@ double Rectangle::getArea() const
 bool Rectangle::isPointIn(int x, int y) const
 {
 	Shape::point p(x, y);
-	return p.x >= getPointAtIndex(0).x && p.x >= getPointAtIndex(1).x &&
+	return p.x >= getPointAtIndex(0).x && p.x <= getPointAtIndex(2).x &&
 		p.y <= getPointAtIndex(0).y && p.y >= getPointAtIndex(2).y;
 }


### PR DESCRIPTION
prob a typo, but the current implementation of the x-coordinate boundary checks if p.x is greater than or equal to getPointAtIndex(0).x and getPointAtIndex(1).x, which both refer to the same vertical boundary. This will not properly constrain the point within the rectangle's width.