### PR TITLE
Update SharedPtr.hpp

### DIFF
--- a/Week 13/SmartPointers/SharedAndWeak/SharedPtr.hpp
+++ b/Week 13/SmartPointers/SharedAndWeak/SharedPtr.hpp
@@ -73,7 +73,7 @@ template<class T>
 inline SharedPtr<T>::SharedPtr(WeakPtr<T>& ptr)
 {
 	data = ptr.data;
-	counter = other.counter;
+	counter = ptr.counter;
 	if (counter)
 	{
 		counter->addSharedPtr();

--- a/Week 13/SmartPointers/SharedAndWeak/SharedPtr.hpp
+++ b/Week 13/SmartPointers/SharedAndWeak/SharedPtr.hpp
@@ -33,6 +33,9 @@ struct Counter
 
 };
 
+template <class V>
+class WeakPtr;
+
 template <typename T>
 class SharedPtr
 {
@@ -45,6 +48,7 @@ class SharedPtr
 	void copyFrom(const SharedPtr<T>& other);
 	void moveFrom(SharedPtr<T>&& other);
 
+	SharedPtr(WeakPtr<T>& ptr);
 public:
 	SharedPtr();
 	SharedPtr(T* data);
@@ -64,6 +68,17 @@ public:
 	
 	~SharedPtr();
 };
+
+template<class T>
+inline SharedPtr<T>::SharedPtr(WeakPtr<T>& ptr)
+{
+	data = ptr.data;
+	counter = other.counter;
+	if (counter)
+	{
+		counter->addSharedPtr();
+	}
+}
 
 template <typename T>
 void SharedPtr<T>::free()


### PR DESCRIPTION
Adding constructor in SharedPtr to fix member function lock in WeakPtr 

Lock function should return instance of SharedPtr with the same counter and not creating new Counter
(Counters should depend from each other).