### PR TITLE
Update NVector.cpp

### DIFF
--- a/Week 07/NVector/NVector.cpp
+++ b/Week 07/NVector/NVector.cpp
@@ -144,7 +144,7 @@ bool operator||(const NVector& lhs, const NVector& rhs)
         }
         
         // Calculate the ratio of the current components
-        double currentRatio = lhs[i] / rhs[i];
+        double currentRatio = (double)lhs[i] / rhs[i];
         // If the ratio is not set, set it. Otherwise, compare it with the current ratio
         if (!ratioSet) 
         {


### PR DESCRIPTION
Cast at least one of the numbers, otherwise treated as int and won't return rational number(double), but int