### PR TITLE
fix memory leaks

### DIFF
--- a/Utils/ExamSI/source.cpp
+++ b/Utils/ExamSI/source.cpp
@@ -254,7 +254,9 @@ public:
         ifs.read((char*)data, size);
         ifs.close();
         
-        return HexArray(data, size);
+        HexArray toReturn(data, size);
+        delete[] data;
+        return toReturn;
     }
 
     Deserializator* clone() const {
@@ -280,7 +282,9 @@ public:
         }
 
         ifs.close();
-        return HexArray(res, size);
+        HexArray toReturn(res, size);
+        delete[] res;
+        return toReturn;
     }
 
     Deserializator* clone() const {
@@ -304,7 +308,9 @@ public:
         }
 
         ifs.close();
-        return HexArray(res, size);
+        HexArray toReturn(res, size);
+        delete[] res;
+        return toReturn;
     }
 
     Deserializator* clone() const {


### PR DESCRIPTION
we should delete data array because the object already made its own copy so keeping the original array would result in a memory leak